### PR TITLE
Add logging proxy

### DIFF
--- a/2017-10/ClientAPIs/adam/__init__.py
+++ b/2017-10/ClientAPIs/adam/__init__.py
@@ -7,3 +7,4 @@ from adam.batch import Batch
 from adam.project import Projects
 from adam.rest_proxy import RestRequests
 from adam.rest_proxy import AuthorizingRestProxy
+from adam.rest_proxy import LoggingRestProxy


### PR DESCRIPTION
I find myself constantly reimplementing this for debugging, so I decided to just clean it up as a logging proxy. I'll separately send a PR to update test.py (finally) that I'll wait to check in until projects support has been pushed to prod (currently checked in and usable in devserver but not updated in prod).