### PR TITLE
Add client support for permissions management

### DIFF
--- a/2017-10/ClientAPIs/adam/__init__.py
+++ b/2017-10/ClientAPIs/adam/__init__.py
@@ -7,6 +7,8 @@ from adam.batch import Batch
 from adam.batch import Batches
 from adam.batch_runner import BatchRunner
 from adam.group import Groups
+from adam.permission import Permission
+from adam.permission import Permissions
 from adam.project import Projects
 from adam.service import Service
 from adam.rest_proxy import RestRequests

--- a/2017-10/ClientAPIs/adam/permission.py
+++ b/2017-10/ClientAPIs/adam/permission.py
@@ -1,0 +1,163 @@
+"""
+    permission.py
+"""
+
+from datetime import datetime
+from tabulate import tabulate
+
+class Permission(object):
+    def __init__(self, right, target_type, target_uuid):
+        """Creates representation of permission.
+        
+        Args:
+            right: must be one of "READ", "WRITE", "ADMIN", "GRANT_READ", "GRANT_WRITE"
+            target_type: must be one of "PROJECT", "BATCH", "GROUP"
+            target_uuid: uuid of object to be granted permission to
+        """
+        self._right = right
+        self._target_type = target_type
+        self._target_uuid = target_uuid
+
+    def __repr__(self):
+        return "Permission [%s, %s, %s]" % (self._right, self._target_type, self._target_uuid)
+    
+    def get_right(self):
+        return self._right
+        
+    def get_target_type(self):
+        return self._target_type
+        
+    def get_target_uuid(self):
+        return self._target_uuid
+
+class Permissions(object):
+    """Module for managing permissions.
+
+    """
+    
+    def __init__(self, rest):
+        self._rest = rest
+        
+    def __repr__(self):
+        return "Permissions module"
+    
+    def grant_user_permission(self, user_email, permission):
+        code, response = self._rest.post('/user_permission/' + user_email, 
+            {'right': permission.get_right(),
+             'target_type': permission.get_target_type(),
+             'target_id': permission.get_target_uuid()})
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+    
+    def grant_group_permission(self, group_uuid, permission):
+        code, response = self._rest.post('/group_permission/' + group_uuid, 
+            {'right': permission.get_right(),
+             'target_type': permission.get_target_type(),
+             'target_id': permission.get_target_uuid()})
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+    
+    def revoke_user_permission(self, user_email, permission):
+        code = self._rest.delete(
+            "/user_permission/%s?right=%s&target_type=%s&target_id=%s" % (
+            user_email, 
+            permission.get_right(), 
+            permission.get_target_type(), 
+            permission.get_target_uuid()))
+        
+        if code != 204:
+            raise RuntimeError("Server status code: %s" % (code))
+    
+    def revoke_group_permission(self, group_uuid, permission):
+        code = self._rest.delete(
+            "/group_permission/%s?right=%s&target_type=%s&target_id=%s" % (
+            group_uuid, 
+            permission.get_right(), 
+            permission.get_target_type(), 
+            permission.get_target_uuid()))
+        
+        if code != 204:
+            raise RuntimeError("Server status code: %s" % (code))
+        
+    
+    def new_group(self, name, description):
+        code, response = self._rest.post('/group', 
+            {'name': name, 'description': description})
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+        
+        return Group(response['uuid'], name, description)
+    
+    def delete_group(self, uuid):
+        code = self._rest.delete('/group/' + uuid)
+        
+        if code != 204:
+            raise RuntimeError("Server status code: %s" % (code))
+    
+    def add_user_to_group(self, user, group):
+        code, response = self._rest.post('/group/' + group + '/member',
+            {'member_id': user, 'member_type': 'USER'})
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+    
+    def remove_user_from_group(self, user, group):
+        code = self._rest.delete('/group/' + group + '/member?member_id=' + user + '&member_type=USER')
+        
+        if code != 204:
+            raise RuntimeError("Server status code: %s" % (code))
+    
+    def add_group_to_group(self, group1, group2):
+        code, response = self._rest.post('/group/' + group2 + '/member',
+            {'member_id': group1, 'member_type': 'GROUP'})
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+    
+    def remove_group_from_group(self, group1, group2):
+        code = self._rest.delete('/group/' + group2 + '/member?member_id=' + group1 + '&member_type=GROUP')
+        
+        if code != 204:
+            raise RuntimeError("Server status code: %s" % (code))
+    
+    def _get_group_members(self, group):
+        code, response = self._rest.get('/group/' + group + '/member')
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+        
+        return response['items']
+    
+    def get_group_members(self, group):
+        return [GroupMember(m['member_id'], m['member_type']) for m in self._get_group_members(group)]
+    
+    def print_group_members(self, group):
+        members = self._get_group_members(group)
+        print(tabulate(members, headers="keys", tablefmt="fancy_grid"))
+    
+    def _get_memberships(self, group=None):
+        url = '/group_membership?recursive=true&expand=true'
+        if group is not None:
+            url = url + '&group_uuid=' + group
+        code, response = self._rest.get(url)
+        
+        if code != 200:
+            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
+        
+        return response['items']
+    
+    def get_group_memberships(self, group):
+        return [Group(g['uuid'], g.get('name'), g.get('description')) for g in self._get_memberships(group)]
+    
+    def print_group_memberships(self, group):
+        groups = self._get_memberships(group)
+        print(tabulate(groups, headers="keys", tablefmt="fancy_grid"))
+    
+    def get_my_memberships(self):
+        return self.get_group_memberships(None)
+        
+    def print_my_memberships(self):
+        self.print_group_memberships(None)

--- a/2017-10/ClientAPIs/adam/permission.py
+++ b/2017-10/ClientAPIs/adam/permission.py
@@ -11,15 +11,29 @@ class Permission(object):
         
         Args:
             right: must be one of "READ", "WRITE", "ADMIN", "GRANT_READ", "GRANT_WRITE"
-            target_type: must be one of "PROJECT", "BATCH", "GROUP"
+            target_type: must be one of "PROJECT", "BATCH", "SETTINGS", "GROUP"
             target_uuid: uuid of object to be granted permission to
         """
+        accepted_rights = ["READ", "WRITE", "ADMIN", "GRANT_READ", "GRANT_WRITE"]
+        if not right in accepted_rights:
+            raise KeyError("Right must be one of %s." % (accepted_rights))
+        
+        accepted_targets = ["PROJECT", "BATCH", "SETTINGS", "GROUP"]
+        if not target_type in accepted_targets:
+            raise KeyError("Target type must be one of %s." % (accepted_targets))
+        
+        if target_uuid is None:
+            raise KeyError("Target UUID is required.") 
+            
         self._right = right
         self._target_type = target_type
         self._target_uuid = target_uuid
 
     def __repr__(self):
         return "Permission [%s, %s, %s]" % (self._right, self._target_type, self._target_uuid)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
     
     def get_right(self):
         return self._right
@@ -81,83 +95,57 @@ class Permissions(object):
         if code != 204:
             raise RuntimeError("Server status code: %s" % (code))
         
-    
-    def new_group(self, name, description):
-        code, response = self._rest.post('/group', 
-            {'name': name, 'description': description})
+    def get_my_permissions(self):
+        code, response = self._rest.get("/user_permission?recursive=true")
         
         if code != 200:
-            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
-        
-        return Group(response['uuid'], name, description)
-    
-    def delete_group(self, uuid):
-        code = self._rest.delete('/group/' + uuid)
-        
-        if code != 204:
             raise RuntimeError("Server status code: %s" % (code))
+        
+        permissions = {}
+        for key in response:
+            permissions[key] = [Permission(p['right'], p['target_type'], p['target_id']) for p in response[key]]
+        
+        return permissions
     
-    def add_user_to_group(self, user, group):
-        code, response = self._rest.post('/group/' + group + '/member',
-            {'member_id': user, 'member_type': 'USER'})
+    def print_my_permissions(self):
+        permissions = self.get_my_permissions()
+        
+        table = []
+        for k in permissions:
+            for p in permissions[k]:
+                via = "Group %s" % k if k != '' else 'Directly granted'
+                table.append({
+                    'Right': p.get_right(),
+                    'Target': "%s %s" % (p.get_target_type(), p.get_target_uuid()), 
+                    'Permitted via': via
+                })
+                
+        print(tabulate(table, headers="keys", tablefmt="fancy_grid"))
+    
+    def get_group_permissions(self, group_uuid):
+        code, response = self._rest.get(
+            "/group_permission/%s?recursive=true" % (group_uuid))
         
         if code != 200:
-            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
-    
-    def remove_user_from_group(self, user, group):
-        code = self._rest.delete('/group/' + group + '/member?member_id=' + user + '&member_type=USER')
-        
-        if code != 204:
             raise RuntimeError("Server status code: %s" % (code))
-    
-    def add_group_to_group(self, group1, group2):
-        code, response = self._rest.post('/group/' + group2 + '/member',
-            {'member_id': group1, 'member_type': 'GROUP'})
         
-        if code != 200:
-            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
-    
-    def remove_group_from_group(self, group1, group2):
-        code = self._rest.delete('/group/' + group2 + '/member?member_id=' + group1 + '&member_type=GROUP')
+        permissions = {}
+        for key in response:
+            permissions[key] = [Permission(p['right'], p['target_type'], p['target_id']) for p in response[key]]
         
-        if code != 204:
-            raise RuntimeError("Server status code: %s" % (code))
+        return permissions
     
-    def _get_group_members(self, group):
-        code, response = self._rest.get('/group/' + group + '/member')
+    def print_group_permissions(self, group_uuid):
+        permissions = self.get_group_permissions(group_uuid)
         
-        if code != 200:
-            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
-        
-        return response['items']
-    
-    def get_group_members(self, group):
-        return [GroupMember(m['member_id'], m['member_type']) for m in self._get_group_members(group)]
-    
-    def print_group_members(self, group):
-        members = self._get_group_members(group)
-        print(tabulate(members, headers="keys", tablefmt="fancy_grid"))
-    
-    def _get_memberships(self, group=None):
-        url = '/group_membership?recursive=true&expand=true'
-        if group is not None:
-            url = url + '&group_uuid=' + group
-        code, response = self._rest.get(url)
-        
-        if code != 200:
-            raise RuntimeError("Server status code: %s; Response: %s" % (code, response))
-        
-        return response['items']
-    
-    def get_group_memberships(self, group):
-        return [Group(g['uuid'], g.get('name'), g.get('description')) for g in self._get_memberships(group)]
-    
-    def print_group_memberships(self, group):
-        groups = self._get_memberships(group)
-        print(tabulate(groups, headers="keys", tablefmt="fancy_grid"))
-    
-    def get_my_memberships(self):
-        return self.get_group_memberships(None)
-        
-    def print_my_memberships(self):
-        self.print_group_memberships(None)
+        table = []
+        for k in permissions:
+            for p in permissions[k]:
+                via = "Group %s" % k if k != group_uuid else 'Directly granted'
+                table.append({
+                    'Right': p.get_right(),
+                    'Target': "%s %s" % (p.get_target_type(), p.get_target_uuid()), 
+                    'Permitted via': via
+                })
+                
+        print(tabulate(table, headers="keys", tablefmt="fancy_grid"))

--- a/2017-10/ClientAPIs/adam/permission.py
+++ b/2017-10/ClientAPIs/adam/permission.py
@@ -95,8 +95,12 @@ class Permissions(object):
         if code != 204:
             raise RuntimeError("Server status code: %s" % (code))
         
-    def get_my_permissions(self):
-        code, response = self._rest.get("/user_permission?recursive=true")
+    def get_my_permissions(self, user_superuser_only=None):
+        url = "/user_permission?recursive=true"
+        if user_superuser_only is not None:
+            url = "/user_permission/%s?recursive=true" % (user_superuser_only)
+            
+        code, response = self._rest.get(url)
         
         if code != 200:
             raise RuntimeError("Server status code: %s" % (code))
@@ -107,8 +111,8 @@ class Permissions(object):
         
         return permissions
     
-    def print_my_permissions(self):
-        permissions = self.get_my_permissions()
+    def print_my_permissions(self, user_superuser_only=None):
+        permissions = self.get_my_permissions(user_superuser_only)
         
         table = []
         for k in permissions:

--- a/2017-10/ClientAPIs/adam/permission_test.py
+++ b/2017-10/ClientAPIs/adam/permission_test.py
@@ -115,6 +115,16 @@ class PermissionsTest(unittest.TestCase):
         ps = permissions.get_my_permissions()
         self.assertEqual(ps, {'': [Permission('ADMIN', 'PROJECT', 'id')]})
             
+    def test_get_your_permissions(self):
+        rest = _RestProxyForTest()
+        permissions = Permissions(rest)
+        
+        rest.expect_get('/user_permission/other_user?recursive=true', 200,
+            {'': [{'right': 'ADMIN', 'target_type': 'PROJECT', 'target_id': 'id'}]})
+        
+        ps = permissions.get_my_permissions(user_superuser_only='other_user')
+        self.assertEqual(ps, {'': [Permission('ADMIN', 'PROJECT', 'id')]})
+            
     def test_get_group_permissions(self):
         rest = _RestProxyForTest()
         permissions = Permissions(rest)

--- a/2017-10/ClientAPIs/adam/permission_test.py
+++ b/2017-10/ClientAPIs/adam/permission_test.py
@@ -1,0 +1,158 @@
+from adam import Groups
+from adam.group import Group
+from adam.group import GroupMember
+from adam.rest_proxy import _RestProxyForTest
+import unittest
+
+class GroupTest(unittest.TestCase):
+    """Unit tests for group object
+
+    """
+    
+    def test_get_methods(self):
+        group = Group("uuid", None, None)
+        self.assertEqual("uuid", group.get_uuid())
+        self.assertEqual(None, group.get_name())
+        self.assertEqual(None, group.get_description())
+        
+        group = Group("uuid","name", "description")
+        self.assertEqual("uuid", group.get_uuid())
+        self.assertEqual("name", group.get_name())
+        self.assertEqual("description", group.get_description())
+
+class GroupMemberTest(unittest.TestCase):
+    """Unit tests for group member object
+
+    """
+    
+    def test_get_methods(self):
+        member = GroupMember("id", "USER")
+        self.assertEqual("id", member.get_id())
+        self.assertEqual("USER", member.get_type())
+
+class GroupsTest(unittest.TestCase):
+    """Unit tests for groups module
+
+    """
+    
+    def test_new_group(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        expected_data = {'name': None, 'description': None}
+        rest.expect_post("/group", check_input, 200, {'uuid': 'aaa'})
+        group = groups.new_group(None, None)
+        self.assertEqual("aaa", group.get_uuid())
+        self.assertEqual(None, group.get_name())
+        self.assertEqual(None, group.get_description())
+            
+        expected_data = {'name': 'nnn', 'description': 'ddd'}
+        rest.expect_post("/group", check_input, 200, {'uuid': 'ccc'})
+        group = groups.new_group('nnn', 'ddd')
+        self.assertEqual("ccc", group.get_uuid())
+        self.assertEqual('nnn', group.get_name())
+        self.assertEqual('ddd', group.get_description())
+        
+        
+        rest.expect_post("/group", check_input, 404, {})
+        with self.assertRaises(RuntimeError):
+            group = groups.new_group('nnn', 'ddd')
+        
+    def test_delete_group(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+        
+        rest.expect_delete("/group/aaa", 204)
+        groups.delete_group('aaa')
+        
+        # 200 isn't a valid return value for delete calls right now
+        rest.expect_delete("/group/aaa", 200)
+        with self.assertRaises(RuntimeError):
+            groups.delete_group('aaa')
+            
+        rest.expect_delete("/group/aaa", 404)
+        with self.assertRaises(RuntimeError):
+            groups.delete_group('aaa')
+    
+    def test_add_group_member(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        expected_data = {'member_id': "aaa", 'member_type': "USER"}
+        rest.expect_post("/group/g1/member", check_input, 200, {})
+        groups.add_user_to_group('aaa', 'g1')
+            
+        expected_data = {'member_id': "bbb", 'member_type': "GROUP"}
+        rest.expect_post("/group/g1/member", check_input, 200, {})
+        groups.add_group_to_group('bbb', 'g1')
+    
+    def test_delete_group_member(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+            
+        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=USER", 204)
+        groups.remove_user_from_group('aaa', 'g1')
+            
+        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=GROUP", 204)
+        groups.remove_group_from_group('aaa', 'g1')
+            
+        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=USER", 404)
+        with self.assertRaises(RuntimeError):
+            groups.remove_user_from_group('aaa', 'g1')
+            
+        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=GROUP", 404)
+        with self.assertRaises(RuntimeError):
+            groups.remove_group_from_group('aaa', 'g1')
+        
+    def test_group_memberships(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+        
+        rest.expect_get('/group_membership?recursive=true&expand=true&group_uuid=g1', 200, 
+            {'items': []})
+        memberships = groups.get_group_memberships('g1')
+        self.assertTrue(len(memberships) == 0)
+        
+        rest.expect_get('/group_membership?recursive=true&expand=true&group_uuid=g1', 200, 
+            {'items': [{'uuid': 'g2', 'name': 'n', 'description': 'd'}, {'uuid': 'g3'}]})
+        memberships = groups.get_group_memberships('g1')
+        self.assertTrue(len(memberships) == 2)
+        self.assertTrue('g2' in [g.get_uuid() for g in memberships])
+        self.assertTrue('g3' in [g.get_uuid() for g in memberships])
+        
+        rest.expect_get('/group_membership?recursive=true&expand=true', 200, 
+            {'items': [{'uuid': 'g2', 'name': 'n', 'description': 'd'}, {'uuid': 'g3'}]})
+        memberships = groups.get_my_memberships()
+        self.assertTrue(len(memberships) == 2)
+        self.assertTrue('g2' in [g.get_uuid() for g in memberships])
+        self.assertTrue('g3' in [g.get_uuid() for g in memberships])
+    
+    def test_group_members(self):
+        rest = _RestProxyForTest()
+        groups = Groups(rest)
+        
+        rest.expect_get('/group/g1/member', 200, {'items': []})
+        members = groups.get_group_members('g1')
+        self.assertTrue(len(members) == 0)
+        
+        rest.expect_get('/group/g1/member', 200,
+            {'items': [{'member_id': 'u1', 'member_type': 'USER'},
+                       {'member_id': 'g2', 'member_type': 'GROUP'}]})
+        members = groups.get_group_members('g1')
+        self.assertTrue(len(members) == 2)
+        self.assertTrue('u1' in [g.get_id() for g in members if g.get_type() == 'USER'])
+        self.assertTrue('g2' in [g.get_id() for g in members if g.get_type() == 'GROUP'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/2017-10/ClientAPIs/adam/permission_test.py
+++ b/2017-10/ClientAPIs/adam/permission_test.py
@@ -1,157 +1,131 @@
-from adam import Groups
-from adam.group import Group
-from adam.group import GroupMember
+from adam import Permission
+from adam import Permissions
 from adam.rest_proxy import _RestProxyForTest
 import unittest
 
-class GroupTest(unittest.TestCase):
-    """Unit tests for group object
+class PermissionTest(unittest.TestCase):
+    """Unit tests for permission object
 
     """
     
     def test_get_methods(self):
-        group = Group("uuid", None, None)
-        self.assertEqual("uuid", group.get_uuid())
-        self.assertEqual(None, group.get_name())
-        self.assertEqual(None, group.get_description())
-        
-        group = Group("uuid","name", "description")
-        self.assertEqual("uuid", group.get_uuid())
-        self.assertEqual("name", group.get_name())
-        self.assertEqual("description", group.get_description())
+        permission = Permission("GRANT_READ", "SETTINGS", "uuid")
+        self.assertEqual("GRANT_READ", permission.get_right())
+        self.assertEqual("SETTINGS", permission.get_target_type())
+        self.assertEqual("uuid", permission.get_target_uuid())
 
-class GroupMemberTest(unittest.TestCase):
-    """Unit tests for group member object
+    def test_bad_inputs(self):
+        with self.assertRaises(KeyError):
+            Permission(None, "PROJECT", "id")
+        with self.assertRaises(KeyError):
+            Permission("Not a right", "PROJECT", "id")
+        with self.assertRaises(KeyError):
+            Permission("Admin", "PROJECT", "id")  # Case sensitive
+        with self.assertRaises(KeyError):
+            Permission("ADMIN", None, "id")
+        with self.assertRaises(KeyError):
+            Permission("ADMIN", "not a target type", "id")
+        with self.assertRaises(KeyError):
+            Permission("ADMIN", "pROJECT", "id")  # Case sensitive
+        with self.assertRaises(KeyError):
+            Permission("ADMIN", "PROJECT", None)  # Case sensitive
+
+class PermissionsTest(unittest.TestCase):
+    """Unit tests for permissions module
 
     """
     
-    def test_get_methods(self):
-        member = GroupMember("id", "USER")
-        self.assertEqual("id", member.get_id())
-        self.assertEqual("USER", member.get_type())
-
-class GroupsTest(unittest.TestCase):
-    """Unit tests for groups module
-
-    """
-    
-    def test_new_group(self):
+    def test_grant_user_permission(self):
         rest = _RestProxyForTest()
-        groups = Groups(rest)
+        permissions = Permissions(rest)
 
         expected_data = {}
         def check_input(data_dict):
             self.assertEqual(expected_data, data_dict)
             return True
-            
-        expected_data = {'name': None, 'description': None}
-        rest.expect_post("/group", check_input, 200, {'uuid': 'aaa'})
-        group = groups.new_group(None, None)
-        self.assertEqual("aaa", group.get_uuid())
-        self.assertEqual(None, group.get_name())
-        self.assertEqual(None, group.get_description())
-            
-        expected_data = {'name': 'nnn', 'description': 'ddd'}
-        rest.expect_post("/group", check_input, 200, {'uuid': 'ccc'})
-        group = groups.new_group('nnn', 'ddd')
-        self.assertEqual("ccc", group.get_uuid())
-        self.assertEqual('nnn', group.get_name())
-        self.assertEqual('ddd', group.get_description())
         
+        expected_data = {'right': 'ADMIN', 'target_type': 'PROJECT', 'target_id': 'id'}
+        rest.expect_post('/user_permission/u1', check_input, 200, expected_data)
         
-        rest.expect_post("/group", check_input, 404, {})
+        p1 = Permission('ADMIN', 'PROJECT', 'id')
+        permissions.grant_user_permission('u1', p1)
+        
+        rest.expect_post('/user_permission/u1', check_input, 404, {})
         with self.assertRaises(RuntimeError):
-            group = groups.new_group('nnn', 'ddd')
-        
-    def test_delete_group(self):
-        rest = _RestProxyForTest()
-        groups = Groups(rest)
-        
-        rest.expect_delete("/group/aaa", 204)
-        groups.delete_group('aaa')
-        
-        # 200 isn't a valid return value for delete calls right now
-        rest.expect_delete("/group/aaa", 200)
-        with self.assertRaises(RuntimeError):
-            groups.delete_group('aaa')
-            
-        rest.expect_delete("/group/aaa", 404)
-        with self.assertRaises(RuntimeError):
-            groups.delete_group('aaa')
+            permissions.grant_user_permission('u1', p1)
     
-    def test_add_group_member(self):
+    def test_grant_group_permission(self):
         rest = _RestProxyForTest()
-        groups = Groups(rest)
+        permissions = Permissions(rest)
 
         expected_data = {}
         def check_input(data_dict):
             self.assertEqual(expected_data, data_dict)
             return True
-            
-        expected_data = {'member_id': "aaa", 'member_type': "USER"}
-        rest.expect_post("/group/g1/member", check_input, 200, {})
-        groups.add_user_to_group('aaa', 'g1')
-            
-        expected_data = {'member_id': "bbb", 'member_type': "GROUP"}
-        rest.expect_post("/group/g1/member", check_input, 200, {})
-        groups.add_group_to_group('bbb', 'g1')
-    
-    def test_delete_group_member(self):
-        rest = _RestProxyForTest()
-        groups = Groups(rest)
-            
-        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=USER", 204)
-        groups.remove_user_from_group('aaa', 'g1')
-            
-        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=GROUP", 204)
-        groups.remove_group_from_group('aaa', 'g1')
-            
-        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=USER", 404)
+        
+        expected_data = {'right': 'ADMIN', 'target_type': 'PROJECT', 'target_id': 'id'}
+        rest.expect_post('/group_permission/g1', check_input, 200, expected_data)
+        
+        p1 = Permission('ADMIN', 'PROJECT', 'id')
+        permissions.grant_group_permission('g1', p1)
+        
+        rest.expect_post('/group_permission/g1', check_input, 404, {})
         with self.assertRaises(RuntimeError):
-            groups.remove_user_from_group('aaa', 'g1')
+            permissions.grant_group_permission('g1', p1)
+        
+    def test_revoke_user_permission(self):
+        rest = _RestProxyForTest()
+        permissions = Permissions(rest)
+        
+        rest.expect_delete(
+            '/user_permission/u1?right=ADMIN&target_type=PROJECT&target_id=id', 204)
             
-        rest.expect_delete("/group/g1/member?member_id=aaa&member_type=GROUP", 404)
+        p1 = Permission('ADMIN', 'PROJECT', 'id')
+        permissions.revoke_user_permission('u1', p1)
+        
+        rest.expect_delete(
+            '/user_permission/u1?right=ADMIN&target_type=PROJECT&target_id=id', 200)
+            
         with self.assertRaises(RuntimeError):
-            groups.remove_group_from_group('aaa', 'g1')
+            permissions.revoke_user_permission('u1', p1)
         
-    def test_group_memberships(self):
+    def test_revoke_group_permission(self):
         rest = _RestProxyForTest()
-        groups = Groups(rest)
+        permissions = Permissions(rest)
         
-        rest.expect_get('/group_membership?recursive=true&expand=true&group_uuid=g1', 200, 
-            {'items': []})
-        memberships = groups.get_group_memberships('g1')
-        self.assertTrue(len(memberships) == 0)
+        rest.expect_delete(
+            '/group_permission/g1?right=ADMIN&target_type=PROJECT&target_id=id', 204)
+            
+        p1 = Permission('ADMIN', 'PROJECT', 'id')
+        permissions.revoke_group_permission('g1', p1)
         
-        rest.expect_get('/group_membership?recursive=true&expand=true&group_uuid=g1', 200, 
-            {'items': [{'uuid': 'g2', 'name': 'n', 'description': 'd'}, {'uuid': 'g3'}]})
-        memberships = groups.get_group_memberships('g1')
-        self.assertTrue(len(memberships) == 2)
-        self.assertTrue('g2' in [g.get_uuid() for g in memberships])
-        self.assertTrue('g3' in [g.get_uuid() for g in memberships])
-        
-        rest.expect_get('/group_membership?recursive=true&expand=true', 200, 
-            {'items': [{'uuid': 'g2', 'name': 'n', 'description': 'd'}, {'uuid': 'g3'}]})
-        memberships = groups.get_my_memberships()
-        self.assertTrue(len(memberships) == 2)
-        self.assertTrue('g2' in [g.get_uuid() for g in memberships])
-        self.assertTrue('g3' in [g.get_uuid() for g in memberships])
-    
-    def test_group_members(self):
+        rest.expect_delete(
+            '/group_permission/g1?right=ADMIN&target_type=PROJECT&target_id=id', 200)
+            
+        with self.assertRaises(RuntimeError):
+            permissions.revoke_group_permission('g1', p1)
+            
+    def test_get_my_permissions(self):
         rest = _RestProxyForTest()
-        groups = Groups(rest)
+        permissions = Permissions(rest)
         
-        rest.expect_get('/group/g1/member', 200, {'items': []})
-        members = groups.get_group_members('g1')
-        self.assertTrue(len(members) == 0)
+        rest.expect_get('/user_permission?recursive=true', 200,
+            {'': [{'right': 'ADMIN', 'target_type': 'PROJECT', 'target_id': 'id'}]})
         
-        rest.expect_get('/group/g1/member', 200,
-            {'items': [{'member_id': 'u1', 'member_type': 'USER'},
-                       {'member_id': 'g2', 'member_type': 'GROUP'}]})
-        members = groups.get_group_members('g1')
-        self.assertTrue(len(members) == 2)
-        self.assertTrue('u1' in [g.get_id() for g in members if g.get_type() == 'USER'])
-        self.assertTrue('g2' in [g.get_id() for g in members if g.get_type() == 'GROUP'])
+        ps = permissions.get_my_permissions()
+        self.assertEqual(ps, {'': [Permission('ADMIN', 'PROJECT', 'id')]})
+            
+    def test_get_group_permissions(self):
+        rest = _RestProxyForTest()
+        permissions = Permissions(rest)
+        
+        rest.expect_get('/group_permission/g1?recursive=true', 200,
+            {'g1': [{'right': 'ADMIN', 'target_type': 'PROJECT', 'target_id': 'id'}],
+             'g2': [{'right': 'READ', 'target_type': 'GROUP', 'target_id': 'id2'}]})
+        
+        ps = permissions.get_group_permissions('g1')
+        self.assertEqual(ps, {'g1': [Permission('ADMIN', 'PROJECT', 'id')],
+                              'g2': [Permission('READ', 'GROUP', 'id2')]})
 
 
 if __name__ == '__main__':

--- a/2017-10/ClientAPIs/adam/service.py
+++ b/2017-10/ClientAPIs/adam/service.py
@@ -7,6 +7,7 @@ from adam.batch import Batch
 from adam.batch import Batches
 from adam.batch_runner import BatchRunner
 from adam.group import Groups
+from adam.permission import Permissions
 from adam.project import Projects
 from adam.timer import Timer
 from adam.rest_proxy import RestRequests
@@ -55,6 +56,7 @@ class Service():
         self.projects = Projects(self.rest)
         self.batches = Batches(self.rest)
         self.groups = Groups(self.rest)
+        self.permissions = Permissions(self.rest)
         
         # Also sets up a project to work in.
         self.project = self.projects.new_project(parent_project, None,
@@ -83,6 +85,9 @@ class Service():
     
     def get_groups_module(self):
         return self.groups
+    
+    def get_permissions_module(self):
+        return self.permissions
     
     def get_batch_runner(self):
         return self.batch_runner

--- a/2017-10/ClientAPIs/tests/permissions_test.py
+++ b/2017-10/ClientAPIs/tests/permissions_test.py
@@ -16,8 +16,6 @@ class PermissionsTest(unittest.TestCase):
     
     """
     def _clean_up(self):
-        permissions = self.service.get_permissions_module()
-        
         # Clean up all the groups. This should automatically clean up any permissions
         # associated with them.
         groups = self.service.get_groups_module()
@@ -204,7 +202,7 @@ class PermissionsTest(unittest.TestCase):
         
         # Can't inspect nonexistent things either.
         with self.assertRaises(RuntimeError):
-            permission.get_group_permissions('not a group')
+            permissions.get_group_permissions('not a group')
         
         groups.delete_group(group1.get_uuid())
 

--- a/2017-10/ClientAPIs/tests/permissions_test.py
+++ b/2017-10/ClientAPIs/tests/permissions_test.py
@@ -28,7 +28,7 @@ class PermissionsTest(unittest.TestCase):
     
     def setUp(self):
         self.service = Service()
-        self.assertTrue(self.service.setup_with_test_account(prod=False))
+        self.assertTrue(self.service.setup_with_test_account())
         self.me = "b612.adam.test@gmail.com"
         self._clean_up()
 

--- a/2017-10/ClientAPIs/tests/permissions_test.py
+++ b/2017-10/ClientAPIs/tests/permissions_test.py
@@ -204,6 +204,10 @@ class PermissionsTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             permissions.get_group_permissions('not a group')
         
+        # Not permitted to inspect other users.
+        with self.assertRaises(RuntimeError):
+            permissions.get_my_permissions(user_superuser_only="some other user")
+        
         groups.delete_group(group1.get_uuid())
 
 

--- a/2017-10/ClientAPIs/tests/permissions_test.py
+++ b/2017-10/ClientAPIs/tests/permissions_test.py
@@ -1,0 +1,213 @@
+# This is janky. Why do we have to do this?
+import sys
+sys.path.append('..')
+
+from adam import Service
+from adam import Permission
+
+import json
+import unittest
+from tabulate import tabulate
+
+import os
+
+class PermissionsTest(unittest.TestCase):
+    """Integration test of permissions management.
+    
+    """
+    def _clean_up(self):
+        permissions = self.service.get_permissions_module()
+        
+        # Clean up all the groups. This should automatically clean up any permissions
+        # associated with them.
+        groups = self.service.get_groups_module()
+        my_groups = groups.get_my_memberships()
+        if len(my_groups) > 0:
+            print("Cleaning up " + str(len(my_groups)) + " groups...")
+        for g in my_groups:
+            groups.delete_group(g.get_uuid())
+        
+    
+    def setUp(self):
+        self.service = Service()
+        self.assertTrue(self.service.setup_with_test_account(prod=False))
+        self.me = "b612.adam.test@gmail.com"
+        self._clean_up()
+
+    def tearDown(self):
+        self.service.teardown()
+        self._clean_up()
+        
+        
+    def test_permission_management(self):
+        permissions = self.service.get_permissions_module()
+        
+        # Create three groups to grant permission to.
+        groups = self.service.get_groups_module()
+        group1 = groups.new_group("name1", "description1")
+        group2 = groups.new_group("name2", "description2")
+        group3 = groups.new_group("name3", "description3")
+        
+        # All permissions lists should be empty.
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): []})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): []})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        
+        # I should have permission to all three groups.
+        pms = permissions.get_my_permissions()
+        self.assertTrue(Permission('ADMIN', 'GROUP', group1.get_uuid()) in pms[''])
+        self.assertTrue(Permission('ADMIN', 'GROUP', group2.get_uuid()) in pms[''])
+        self.assertTrue(Permission('ADMIN', 'GROUP', group3.get_uuid()) in pms[''])
+        
+        # Add WRITE permission for group1 on group2.
+        pm1 = Permission('WRITE', 'GROUP', group2.get_uuid())
+        permissions.grant_group_permission(group1.get_uuid(), pm1)
+        
+        # group1 should have that permissions listed. Other groups should be unaffected.
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): [pm1]})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): []})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        
+        # Add READ permission for group2 on group3.
+        pm2 = Permission('READ', 'GROUP', group3.get_uuid())
+        permissions.grant_group_permission(group2.get_uuid(), pm2)
+        
+        # That should show up in group2's list.
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): [pm1]})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): [pm2]})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        
+        # Add group1 as a member of group2. Now pm2 should show up transitively in
+        # group1's list as well.
+        groups.add_group_to_group(group1.get_uuid(), group2.get_uuid())
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): [pm1],
+                               group2.get_uuid(): [pm2]})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): [pm2]})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        
+        # Add group2 to group3 and add ADMIN permission for group3 on group1
+        # (yes, cycles are OK).
+        pm3 = Permission('ADMIN', 'GROUP', group1.get_uuid())
+        permissions.grant_group_permission(group3.get_uuid(), pm3)
+        groups.add_group_to_group(group2.get_uuid(), group3.get_uuid())
+        
+        # pm3 should show up for everybody.
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): [pm1],
+                               group2.get_uuid(): [pm2],
+                               group3.get_uuid(): [pm3]})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): [pm2],
+                               group3.get_uuid(): [pm3]})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): [pm3]})
+        
+        # All of these transitive permissions should show up in my permissions.
+        pms = permissions.get_my_permissions()
+        self.assertEqual(pms[group1.get_uuid()], [pm1])
+        self.assertEqual(pms[group2.get_uuid()], [pm2])
+        self.assertEqual(pms[group3.get_uuid()], [pm3])
+        
+        # Remove pm3, which should be removed from everybody's lists. The lists should
+        # still include an item for group3 because membership hasn't changed, just with 
+        # no permissions directly granted.
+        permissions.revoke_group_permission(group3.get_uuid(), pm3)
+        pms = permissions.get_group_permissions(group1.get_uuid())
+        self.assertEqual(pms, {group1.get_uuid(): [pm1],
+                               group2.get_uuid(): [pm2],
+                               group3.get_uuid(): []})
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): [pm2],
+                               group3.get_uuid(): []})
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        pms = permissions.get_my_permissions()
+        self.assertEqual(pms[group1.get_uuid()], [pm1])
+        self.assertEqual(pms[group2.get_uuid()], [pm2])
+        self.assertEqual(pms[group3.get_uuid()], [])
+        
+        # Delete group1. All permissions (pm1) involving group1 should no longer exist.
+        groups.delete_group(group1.get_uuid())
+        pms = permissions.get_group_permissions(group2.get_uuid())
+        self.assertEqual(pms, {group2.get_uuid(): [pm2],
+                               group3.get_uuid(): []})  # It's still in group3
+        pms = permissions.get_group_permissions(group3.get_uuid())
+        self.assertEqual(pms, {group3.get_uuid(): []})
+        pms = permissions.get_my_permissions()
+        self.assertFalse(group1.get_uuid() in pms)
+        self.assertEqual(pms[group2.get_uuid()], [pm2])
+        self.assertEqual(pms[group3.get_uuid()], [])
+        
+        # Delete group2. This should remove pm2.
+        groups.delete_group(group2.get_uuid())
+        pms = permissions.get_my_permissions()
+        self.assertFalse(group1.get_uuid() in pms)
+        self.assertFalse(group2.get_uuid() in pms)
+        self.assertEqual(pms[group3.get_uuid()], [])
+        
+        # Now grant and revoke a user permission, just to show it doesn't die.
+        permissions.grant_user_permission(
+            "u1", Permission('READ', 'GROUP', group3.get_uuid()))
+        permissions.revoke_user_permission(
+            "u1", Permission('READ', 'GROUP', group3.get_uuid()))
+        
+        groups.delete_group(group3.get_uuid())
+    
+    def test_permission_mismanagement(self):
+        permissions = self.service.get_permissions_module()
+        
+        # Target object does not exist.
+        with self.assertRaises(RuntimeError):
+            permissions.grant_user_permission(
+                'u1', Permission('READ', 'GROUP', 'wat this is not a group'))
+                
+        groups = self.service.get_groups_module()
+        group1 = groups.new_group("name1", "description1")
+        
+        # Recipient of permission does not exist.
+        with self.assertRaises(RuntimeError):
+            permissions.grant_group_permission(
+                'g1', Permission('READ', 'GROUP', group1.get_uuid()))
+        
+        # Target does not exist.
+        with self.assertRaises(RuntimeError):
+            permissions.grant_group_permission(
+                group1.get_uuid(), Permission('READ', 'GROUP', 'wat this is not a group'))
+        
+        # Finally this works.
+        permissions.grant_group_permission(
+            group1.get_uuid(), Permission('READ', 'GROUP', group1.get_uuid()))
+        
+        # Unable to check authorization (target does not exist).
+        with self.assertRaises(RuntimeError):
+            permissions.revoke_user_permission(
+                "u1", Permission('READ', 'GROUP', 'wat this is not a group'))
+        with self.assertRaises(RuntimeError):
+            permissions.revoke_group_permission(
+                group1.get_uuid(), Permission('READ', 'GROUP', 'wat this is not a group'))
+        
+        # But this is fine. Deleting something that doesn't exist.
+        permissions.revoke_group_permission(
+            'not a group', Permission('READ', 'GROUP', group1.get_uuid()))
+        
+        # Can't inspect nonexistent things either.
+        with self.assertRaises(RuntimeError):
+            permission.get_group_permissions('not a group')
+        
+        groups.delete_group(group1.get_uuid())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dependent on server support being checked in (https://bitbucket.org/b612astrogators/exp1/pull-requests/30/ser-3-expose-permission-management-through/diff). Server support is running in dev, though, and this all works as-is (will flip flag to use prod before checking in).